### PR TITLE
fixing bug in architecture contact

### DIFF
--- a/architecture.html
+++ b/architecture.html
@@ -14,7 +14,7 @@ title: Architecture
 		    		</p>
 		    		<p></p>
 		    		<p>
-		    			Questions? Please contact the <a href="mailto:architecture@alpentalcc.org?Subject=ACC%20Architecture">ACC Architectural Committee</a>
+		    			Questions? Please contact the <a href="mailto:architect@alpentalcc.org?Subject=ACC%20Architecture">ACC Architectural Committee</a>
 		    		</p>
 		    	</blockquote>
 		    </div>


### PR DESCRIPTION
Changed the email from 'architecture@alpentalcc.org' to the correct 'architect@altpentalcc.org'